### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ from pandas_extras import expand_lists
 df = DataFrame(...)
 df.pipe(expand_lists, *args, **kwargs)
 ```
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/pandas-extras/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.